### PR TITLE
add installation of package backports.zoneinfo

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,5 +11,6 @@ cd ..
 
 cp $SRC_DIR/prodigal_modified/prodigal $PREFIX/bin/prodigal_sm
 
+$PYTHON -m pip install backports.zoneinfo
 $PYTHON -m pip install --disable-pip-version-check --no-cache-dir --ignore-installed --no-deps -vv .
 


### PR DESCRIPTION
Module backports.zoneinfo is needed in  Tensorflow of python >= 3.7
Fix bug in the Github Actions testing